### PR TITLE
Feature by creating .env.example file and adding .env in .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_RPC_URL=https://api.mainnet-beta.solana.com

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
Without `VITE_RPC_URL` as env var, you will get `rpcUrlOrConnection` as `undefined`. Created a `.env.example`, so that no one has to suffer in debugging from what I gone through :)